### PR TITLE
fixes ransortable attributes for ransack 1.2

### DIFF
--- a/lib/ransack_ui/adapters/active_record/base.rb
+++ b/lib/ransack_ui/adapters/active_record/base.rb
@@ -37,6 +37,9 @@ module RansackUI
           end
         end
 
+        def ransortable_attributes(auth_object = nil)
+          ransackable_attributes(auth_object).map(&:first)
+        end
       end
     end
   end


### PR DESCRIPTION
@ndbroadbent not sure if overriding all these methods is the correct approach. Can you think of another way to expose the field type without adding it to ransackable_attributes?
