### PR TITLE
Use each ransacker defined type

### DIFF
--- a/lib/ransack_ui/adapters/active_record/base.rb
+++ b/lib/ransack_ui/adapters/active_record/base.rb
@@ -24,7 +24,7 @@ module RansackUI
         # (Default to :string type for ransackers)
         def ransackable_attributes(auth_object = nil)
           columns.map{|c| [c.name, c.type] } +
-          _ransackers.keys.map {|k| [k, :string] }
+          _ransackers.keys.map {|k,v| [k, v.type || :string] }
         end
 
         def ransackable_associations(auth_object = nil)

--- a/lib/ransack_ui/ransack_overrides/adapters/active_record/base.rb
+++ b/lib/ransack_ui/ransack_overrides/adapters/active_record/base.rb
@@ -8,7 +8,7 @@ module Ransack
         # (Default to :string type for ransackers)
         def ransackable_attributes(auth_object = nil)
           columns.map{|c| [c.name, c.type] } +
-          _ransackers.keys.map {|k| [k, :string] }
+          _ransackers.keys.map {|k,v| [k, v.type || :string] }
         end
 
         def self.extended(base)


### PR DESCRIPTION
provides the ransacker defined 'type' for select box data-attributes. 
This will allow the predicate select boxes to use Ransack.type_predicates e.g `@integer = ['eq', 'null', 'lt', 'gt', 'in']`
