### PR TITLE
use controller_path instead of controller_name to keep namespace

### DIFF
--- a/lib/ransack_ui/controller_helpers.rb
+++ b/lib/ransack_ui/controller_helpers.rb
@@ -9,7 +9,7 @@ module RansackUI
     # Can also be called as a function if needed. Will return the search object.
     #
     def load_ransack_search(klass = nil)
-      klass ||= controller_name.classify.constantize
+      klass ||= controller_path.classify.constantize
       @ransack_search = klass.search(params[:q])
       @ransack_search.build_grouping if @ransack_search.groupings.empty?
       @ransack_search


### PR DESCRIPTION
Hi, I am in the process of refactoring fat_free_crm to turn it into a full Rails engine. This includes namespacing the models.
ransack_ui currently isn't working with namespaced models but it will after this simple merge request is accepted. Thanks for all the good work :+1: 
