### PR TITLE
Revert to_s to #{} to avoid early string interpolation

### DIFF
--- a/lib/ransack_ui/view_helpers.rb
+++ b/lib/ransack_ui/view_helpers.rb
@@ -11,11 +11,11 @@ module RansackUI
       end
 
       if options[:theme].to_s == 'bootstrap'
-        link_to nil, :class => 'add_fields btn btn-small btn-primary', 'data-field-type' => type, 'data-content' => fields.to_s do
+        link_to nil, :class => 'add_fields btn btn-small btn-primary', 'data-field-type' => type, 'data-content' => "#{fields}" do
           "<i class=\"icon-plus icon-white\"></i><span>#{name}</span>".html_safe
         end
       else
-        link_to name, nil, :class => 'add_fields', 'data-field-type' => type, 'data-content' => fields.to_s
+        link_to name, nil, :class => 'add_fields', 'data-field-type' => type, 'data-content' => "#{fields}"
       end
     end
 


### PR DESCRIPTION
Turns out #{} and .to_s have a few differences. In this case, where we are inserting rendered content into a html attribute, we need to avoid interpoliation.

Fixes unusual html around 'Add a filter' (near bottom of screengrab)

![image](https://github.com/ndbroadbent/ransack_ui/assets/149198/69731add-95da-4b12-b3a3-466f548dc88c)
