### PR TITLE
WIP: Fixes various Select2 v3 -> v4 upgrade related issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Change Log
+
+## Unreleased 
+
+### 💥 Breaking Changes
+
+* Bumped minimum supported version of Select2 from V3 to V4 (Note: Select2 usage is entirely optional.)
+
+### 🚀 Features
+
+* Moved project ownership from github.com:ndbroadbent/ransack_ui.git to github.com:fatfreecrm/ransack_ui.git
+
+### 🐛 Bug Fixes
+
+* Fixed html issue with "Add a filter" rendering
+
+### 📝  Documentation
+
+* Added CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased 
+## v2.0.0
 
 ### 💥 Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 Provides HTML templates and JavaScript to build a fully functional
 advanced search form using Ransack.
 
-Please note: this project is still in *alpha* and the following instructions are not yet complete/fully working.
-
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/app/assets/javascripts/ransack/predicates.js.coffee
+++ b/app/assets/javascripts/ransack/predicates.js.coffee
@@ -37,5 +37,5 @@ Ransack.predicate_inputs = {}
 Ransack.option_predicates = ['eq', 'eq_any', 'not_eq', 'not_eq_all', 'null', 'not_null']
 
 # Use a tags input for 'in' if Select2 is available
-if Select2?
+if $.fn.select2?
   Ransack.predicate_inputs.in = 'tags'

--- a/app/assets/javascripts/ransack_ui_jquery/search_form.js.coffee.erb
+++ b/app/assets/javascripts/ransack_ui_jquery/search_form.js.coffee.erb
@@ -12,7 +12,7 @@
 
       # Store initial predicates and set up Select2 on select lists in .filters
       containers = el.find('.filters')
-      if Select2?
+      if $.fn.select2?
         @init_select2(containers)
       @store_initial_predicates(containers)
 
@@ -59,17 +59,17 @@
         @destroy_multi_input(multi_input, selected_attribute.val())
 
       # Handle association columns with AJAX autocomplete
-      if selected_attribute.data('ajax-url') and Select2?
+      if selected_attribute.data('ajax-url') and $.fn.select2?
         @set_option_predicates(base_id, available, column_type)
 
       # Handle columns with options detected from validates :inclusion
-      else if selected_attribute.data('select-options') and Select2?
+      else if selected_attribute.data('select-options') and $.fn.select2?
         @set_option_predicates(base_id, available, column_type, true)
 
       # Handle regular columns
       else
-        if Select2?
-          predicate_select2.select2("enable")
+        if $.fn.select2?
+          predicate_select2.prop('disabled', false)
 
           # If Select2 is on query input, remove and set defaults
           if query_select2.length > 0
@@ -102,11 +102,11 @@
             predicate_select.append $("<option value=#{predicate}>#{label}</option>")
 
         # Select first predicate if current selection is invalid
-        if Select2?
-          predicate_select.select2('val', previous_val)
+        if $.fn.select2?
+          predicate_select.val(previous_val)
 
       # Run predicate_changed callback
-      predicate_select.change()
+      predicate_select.trigger('change')
 
       return true
 
@@ -138,14 +138,14 @@
       # Hide query input when not needed
       if p in no_query_predicates
         # If Select2 is on query input, remove and set defaults
-        if Select2? && query_select2.length
+        if $.fn.select2? && query_select2.length
           query_input.select2('destroy')
 
         query_input.val("true")
         query_input.hide()
         query_input.parent().find('.ui-datepicker-trigger').hide()
 
-      if Select2?
+      if $.fn.select2?
         # Turn query input into Select2 tag list when query accepts multiple values
         if p in ["in", "not_in"] || p.match(/_(all|any)$/)
           # Add dummy 'multi' input for select2 if not already added
@@ -226,7 +226,7 @@
           predicate_select.append $("<option value=#{predicate}>#{label}</option>")
 
       # Select first predicate if current selection is invalid
-      predicate_select.select2('val', previous_val)
+      predicate_select.val(previous_val)
 
     # Attempts to find a predicate translation for the specific column type,
     # or returns the default label.
@@ -288,7 +288,7 @@
       # Hide all query inputs
       inputs.hide()
 
-      if Select2?
+      if $.fn.select2?
         # Find newly created input and setup Select2
         multi_query = @element.find('#' + multi_id)
 
@@ -310,12 +310,13 @@
           else
             # Setup Select2 with tagging support (can create options)
             multi_query.select2
-              tags: []
+              data: [], tags: true
               tokenSeparators: [',']
-              formatNoMatches: (t) ->
-                "Add a search term"
+              language:
+                noMatches: (t) ->
+                  "Add a search term"
 
-        multi_query.select2('val', values)
+        multi_query.val(values)
 
     setup_select2_association: (query_input, selected_attribute, multiple = false) ->
       selected_attribute_val = selected_attribute.val()
@@ -329,11 +330,11 @@
           url: selected_attribute.data('ajax-url')
           dataType: 'json'
           type: selected_attribute.data('ajax-type')
-          data: (query, page) ->
+          data: (params) ->
             obj = {}
-            obj[selected_attribute.data('ajax-key')] = query
+            obj[selected_attribute.data('ajax-key')] = params
             obj
-          results: (data, page) ->
+          processResults: (data) ->
             {results: $.map(data, (text, id) -> {id: id, text: text}) }
         initSelection: (element, callback) ->
           data = []
@@ -348,7 +349,7 @@
             callback(multiple and data or data[0])
           else
             # If no label could be found, clear value
-            element.select2('val', '')
+            element.val('')
 
     setup_select2_options: (query_input, selected_attribute, multiple = false) ->
       query_input.select2
@@ -374,7 +375,7 @@
           if data.length
             callback(multiple and data or data[0])
           else
-            element.select2('val', '')
+            element.val('')
 
     add_query_input: (base_input, base_name, id, value) ->
       base_input.after $('<input name="'+base_name+'['+id+'][value]" '+
@@ -401,7 +402,7 @@
       target.before content.replace(regexp, new_id)
       prev_container = target.prev()
 
-      if Select2?
+      if $.fn.select2?
         @init_select2(prev_container)
 
       if $.ransack.button_group_select?
@@ -409,7 +410,7 @@
 
       @store_initial_predicates(prev_container)
       # Fire change event on any new selects.
-      prev_container.find("select").change()
+      prev_container.find("select").trigger('change')
       false
 
     remove_fields: (e) ->
@@ -441,11 +442,11 @@
         width: '230px'
         placeholder: "Select a Field"
         allowClear: true
-        formatSelection: (object, container) ->
+        templateSelection: (object) ->
           # If initializing and element is not present,
           # search for option element in original select tag
           if !object.element
-            this.element.find('option').each (i, option) ->
+            container.find('select option').each (i, option) ->
               if option.value == object.id
                 object.element = option
                 return false

--- a/app/assets/javascripts/ransack_ui_jquery/search_form.js.coffee.erb
+++ b/app/assets/javascripts/ransack_ui_jquery/search_form.js.coffee.erb
@@ -59,7 +59,7 @@
         @destroy_multi_input(multi_input, selected_attribute.val())
 
       # Handle association columns with AJAX autocomplete
-      if selected_attribute.data('ajax-url') and $.fn.select2?
+      if selected_attribute.data('ajax--url') and $.fn.select2?
         @set_option_predicates(base_id, available, column_type)
 
       # Handle columns with options detected from validates :inclusion
@@ -175,7 +175,7 @@
             query_input.css('display', '')
 
             # Handle association columns with AJAX autocomplete
-            if selected_attribute.data('ajax-url')
+            if selected_attribute.data('ajax--url')
               if query_select2.length
                 query_input.hide()
               else
@@ -193,7 +193,7 @@
         return if selected_attribute.data('select-options')
 
         # Don't show query input if ajax auto complete is present on selected attribute
-        unless p in ['eq', 'not_eq'] and selected_attribute.data('ajax-url')
+        unless p in ['eq', 'not_eq'] and selected_attribute.data('ajax--url')
           unless query_input.is(":visible")
             query_input.val('')
             #query_input.show()
@@ -293,7 +293,7 @@
         multi_query = @element.find('#' + multi_id)
 
         # Handle association columns with AJAX autocomplete
-        if selected_attribute.data('ajax-url')
+        if selected_attribute.data('ajax--url')
           # Set label to single association label, if anything was selected
           if query_select2.length && query_input.select2('data')
             query_input_data = query_input.select2('data')
@@ -322,17 +322,17 @@
       selected_attribute_val = selected_attribute.val()
       # Set up Select2 for query input
       query_input.select2
-        placeholder: "Search #{selected_attribute.data('ajax-entity')}"
+        placeholder: "Search #{selected_attribute.data('ajax--entity')}"
         minimumInputLength: 1
         allowClear: true
         multiple: multiple
         ajax:
-          url: selected_attribute.data('ajax-url')
+          url: selected_attribute.data('ajax--url')
           dataType: 'json'
-          type: selected_attribute.data('ajax-type')
+          type: selected_attribute.data('ajax--type')
           data: (params) ->
             obj = {}
-            obj[selected_attribute.data('ajax-key')] = params
+            obj[selected_attribute.data('ajax--key')] = params
             obj
           processResults: (data) ->
             {results: $.map(data, (text, id) -> {id: id, text: text}) }

--- a/app/views/ransack_ui/_condition_fields.html.erb
+++ b/app/views/ransack_ui/_condition_fields.html.erb
@@ -3,13 +3,13 @@
 
   <%= f.attribute_fields do |a| %>
     <span class="fields" data-object-name="<%= f.object_name %>">
-    <%= a.attribute_select({}, :class => 'ransack_attribute') %>
+    <%= a.attribute_select({}, class: 'ransack_attribute') %>
   <% end %>
 
-  <%= f.predicate_select({}, :class => 'ransack_predicate') %>
+  <%= f.predicate_select({}, class: 'ransack_predicate') %>
 
   <%= f.value_fields do |v| %>
     <span class="fields value" data-object-name="<%= f.object_name %>">
-    <%= v.text_field :value, :style => "width: 200px;", :class => "ransack_query" %>
+    <%= v.text_field :value, style: "width: 200px;", class: "ransack_query" %>
   <% end %>
 </div>

--- a/lib/ransack_ui/ransack_overrides/helpers/form_builder.rb
+++ b/lib/ransack_ui/ransack_overrides/helpers/form_builder.rb
@@ -180,16 +180,16 @@ module Ransack
           foreign_klass = attribute_data[:foreign_klass]
 
           if foreign_klass
-            # If field is a foreign key, set up 'data-ajax-*' attributes for auto-complete
+            # If field is a foreign key, set up 'data-ajax--*' attributes for auto-complete
             controller = ActiveSupport::Inflector.tableize(foreign_klass.to_s)
-            html_options[:'data-ajax-entity'] = I18n.translate(controller, default: controller)
+            html_options[:'data-ajax--entity'] = I18n.translate(controller, default: controller)
             if ajax_options[:url]
-              html_options[:'data-ajax-url'] = ajax_options[:url].sub(':controller', controller)
+              html_options[:'data-ajax--url'] = ajax_options[:url].sub(':controller', controller)
             else
-              html_options[:'data-ajax-url'] = "/#{controller}.json"
+              html_options[:'data-ajax--url'] = "/#{controller}.json"
             end
-            html_options[:'data-ajax-type'] = ajax_options[:type] || 'GET'
-            html_options[:'data-ajax-key']  = ajax_options[:key]  || 'query'
+            html_options[:'data-ajax--type'] = ajax_options[:type] || 'GET'
+            html_options[:'data-ajax--key']  = ajax_options[:key]  || 'query'
           end
 
           [

--- a/lib/ransack_ui/version.rb
+++ b/lib/ransack_ui/version.rb
@@ -1,3 +1,3 @@
 module RansackUI
-  VERSION = '1.4.0'.freeze
+  VERSION = '2.0.0'.freeze
 end


### PR DESCRIPTION
This is a work in progress.

Reading through https://select2.org/upgrading/migrating-from-35 there are some important updates when migrating from Select2 v3.5 to v4

Changes:
* Replace cases of `Select2?` with `$.fn.select2`
* `.select2('val', previous_val)` is now `.val(previous_val)`
* `.change()` becomes `.trigger('change')`
* multi-query has an attribute change `tags:[]` becomes `data: [], tags: true`
