### PR TITLE
Override for table name fix for Rails 7.1

### DIFF
--- a/lib/ransack_ui/ransack_overrides/adapters/active_record/context.rb
+++ b/lib/ransack_ui/ransack_overrides/adapters/active_record/context.rb
@@ -1,0 +1,21 @@
+require 'ransack/adapters/active_record/context.rb'
+
+module Ransack
+  module Adapters
+    module ActiveRecord
+      Context.class_eval do
+        def type_for(attr)
+          return nil unless attr && attr.valid?
+          relation     = attr.arel_attribute.relation
+          name         = attr.arel_attribute.name.to_s
+          table        = relation.respond_to?(:table_name) ? relation.table_name : relation.name
+          schema_cache = self.klass.connection.schema_cache
+          unless schema_cache.send(:data_source_exists?, table)
+            raise "No table named #{table} exists."
+          end
+          attr.klass.columns.find { |column| column.name == name }.type
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cherrypicked commit from Ransack 4.1.1 for Rails 7.1 as table_name is deprecated.
https://github.com/activerecord-hackery/ransack/pull/1439/commits/eac3c37d3d9a22179071dd150f01e7a5bfaefa9c