### PR TITLE
Bump ransack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v3.0.0
+
+* Removed direct dependeny on ransack-chronic, for Ransack 4 compatibility
+
 ## v2.0.1
 
 ### 🐛 Bug Fixes

--- a/app/assets/javascripts/ransack_ui_jquery/search_form.js.coffee.erb
+++ b/app/assets/javascripts/ransack_ui_jquery/search_form.js.coffee.erb
@@ -232,9 +232,6 @@
     # or returns the default label.
     # For example, 'lt' on an integer column will be translated to 'is less than',
     # while a date column will have it translated as 'is before'.
-    # This is mainly to avoid confusion when building conditions using Chronic strings.
-    # 'created_at is less than 2 weeks ago' is misleading, and
-    # 'created_at is before 2 weeks ago' is much easier to understand.
     alt_predicate_label_or_default: (p, type, default_label) ->
       return default_label unless Ransack?.alt_predicates_i18n?
       alt_labels = {}

--- a/lib/ransack_ui.rb
+++ b/lib/ransack_ui.rb
@@ -1,6 +1,5 @@
 require 'ransack_ui/version'
 require 'ransack_ui/rails/engine'
-# require 'ransack_chronic'
 
 # Require ransack overrides
 require 'ransack_ui/adapters/active_record'

--- a/lib/ransack_ui.rb
+++ b/lib/ransack_ui.rb
@@ -1,6 +1,6 @@
 require 'ransack_ui/version'
 require 'ransack_ui/rails/engine'
-require 'ransack_chronic'
+# require 'ransack_chronic'
 
 # Require ransack overrides
 require 'ransack_ui/adapters/active_record'

--- a/lib/ransack_ui/adapters/active_record.rb
+++ b/lib/ransack_ui/adapters/active_record.rb
@@ -1,6 +1,6 @@
 # Extend original ransack adapter first
 require 'ransack/constants'
-require 'ransack/adapters/active_record'
+require 'ransack/adapters/active_record/base'
 
 require 'ransack_ui/adapters/active_record/base'
 ActiveRecord::Base.extend RansackUI::Adapters::ActiveRecord::Base

--- a/lib/ransack_ui/version.rb
+++ b/lib/ransack_ui/version.rb
@@ -1,3 +1,3 @@
 module RansackUI
-  VERSION = '2.0.1'.freeze
+  VERSION = '3.0.0'.freeze
 end

--- a/ransack_ui.gemspec
+++ b/ransack_ui.gemspec
@@ -17,6 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  # gem.add_dependency 'ransack_chronic', '>= 1.1.0'
   gem.add_dependency 'ransack'
 end

--- a/ransack_ui.gemspec
+++ b/ransack_ui.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'ransack_chronic', '>= 1.1.0'
-  gem.add_dependency 'ransack', '< 4'
+  gem.add_dependency 'ransack'
 end

--- a/ransack_ui.gemspec
+++ b/ransack_ui.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'ransack_chronic', '>= 1.1.0'
+  # gem.add_dependency 'ransack_chronic', '>= 1.1.0'
   gem.add_dependency 'ransack'
 end

--- a/ransack_ui.gemspec
+++ b/ransack_ui.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ['nathan.f77@gmail.com']
   gem.description   = 'Framework for building a search UI with Ransack'
   gem.summary       = 'UI Builder for Ransack'
-  gem.homepage      = 'https://github.com/ndbroadbent/ransack_ui'
+  gem.homepage      = 'https://github.com/fatfreecrm/ransack_ui'
   gem.license       = 'MIT'
 
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Fix https://github.com/fatfreecrm/ransack_ui/issues/26

Drops ransack_chronic - not compatible with ransack 4; unless a release for https://github.com/ndbroadbent/ransack_chronic/pull/1 is avail.

What's the impact for downstream projects?
At least for fatfreecrm, we didn't appear to render the ransack predicates/I could not actually tell there was a difference.

